### PR TITLE
Provide SDL touch info via InputManager

### DIFF
--- a/QuickSDL/InputManager.cpp
+++ b/QuickSDL/InputManager.cpp
@@ -230,9 +230,9 @@ namespace QuickSDL {
 		return Vector2((float)mMouseXPos, (float)mMouseYPos);
 	}
 
-  Vector2 InputManager::TouchPos() {
-    return Vector2((float)mTouchXPos, (float)mTouchYPos);
-  }
+	Vector2 InputManager::TouchPos() {
+		return Vector2((float)mTouchXPos, (float)mTouchYPos);
+	}
 
 	bool InputManager::MouseButtonDown(MOUSE_BUTTON button) {
 
@@ -349,11 +349,11 @@ namespace QuickSDL {
 		//Updating the mouse state to get the key states of the current frame
 		mMouseState = SDL_GetMouseState(&mMouseXPos, &mMouseYPos);
 
-    SDL_Finger* touchState = SDL_GetTouchFinger(0, 0);
-    if (touchState != NULL) {
-      mTouchXPos = touchState->x;
-      mTouchYPos = touchState->y;
-    }
+		SDL_Finger* touchState = SDL_GetTouchFinger(0, 0);
+		if (touchState != NULL) {
+			mTouchXPos = touchState->x;
+			mTouchYPos = touchState->y;
+		}
 
 		if (joy != NULL) {
 

--- a/QuickSDL/InputManager.cpp
+++ b/QuickSDL/InputManager.cpp
@@ -230,6 +230,10 @@ namespace QuickSDL {
 		return Vector2((float)mMouseXPos, (float)mMouseYPos);
 	}
 
+  Vector2 InputManager::TouchPos() {
+    return Vector2((float)mTouchXPos, (float)mTouchYPos);
+  }
+
 	bool InputManager::MouseButtonDown(MOUSE_BUTTON button) {
 
 		//mask to be using for bit wise operations
@@ -345,6 +349,11 @@ namespace QuickSDL {
 		//Updating the mouse state to get the key states of the current frame
 		mMouseState = SDL_GetMouseState(&mMouseXPos, &mMouseYPos);
 
+    SDL_Finger* touchState = SDL_GetTouchFinger(0, 0);
+    if (touchState != NULL) {
+      mTouchXPos = touchState->x;
+      mTouchYPos = touchState->y;
+    }
 
 		if (joy != NULL) {
 

--- a/QuickSDL/InputManager.h
+++ b/QuickSDL/InputManager.h
@@ -95,6 +95,9 @@ namespace QuickSDL {
 		int mMouseXPos;
 		int mMouseYPos;
 
+    int mTouchXPos;
+    int mTouchYPos;
+
 		SDL_Joystick* joy;
 
 		Uint8* mPrevJoyButtonState;
@@ -148,6 +151,7 @@ namespace QuickSDL {
 		//Returns a Vector2 containing the current mouse position on screen 
 		//------------------------------------------------------------------
 		Vector2 MousePos();
+    Vector2 TouchPos();
 
 		bool JoyButtonDown(int button);
 		bool JoyButtonPressed(int button);

--- a/QuickSDL/InputManager.h
+++ b/QuickSDL/InputManager.h
@@ -95,8 +95,8 @@ namespace QuickSDL {
 		int mMouseXPos;
 		int mMouseYPos;
 
-    int mTouchXPos;
-    int mTouchYPos;
+		int mTouchXPos;
+		int mTouchYPos;
 
 		SDL_Joystick* joy;
 
@@ -151,7 +151,7 @@ namespace QuickSDL {
 		//Returns a Vector2 containing the current mouse position on screen 
 		//------------------------------------------------------------------
 		Vector2 MousePos();
-    Vector2 TouchPos();
+		Vector2 TouchPos();
 
 		bool JoyButtonDown(int button);
 		bool JoyButtonPressed(int button);


### PR DESCRIPTION
This is intended to address #2 , provides a `TouchPos` on InputManager that should work like `MousePos`

Might need a few more changes to initialize the touchpad device, will check shortly